### PR TITLE
Se corrige error donde se creaban registros de clientes nulos.

### DIFF
--- a/src/main/java/robinlb99/tienda/igu/Nueva_venta/ConfirmarCompra.java
+++ b/src/main/java/robinlb99/tienda/igu/Nueva_venta/ConfirmarCompra.java
@@ -30,7 +30,7 @@ public class ConfirmarCompra extends javax.swing.JFrame {
         
         initComponents();
         
-        System.out.println(this.cancelado);
+//        System.out.println(this.cancelado);
         
         if (!this.cancelado) {
             txtRecibe.setText("0");

--- a/src/main/java/robinlb99/tienda/igu/Nueva_venta/ConfirmarCompra.java
+++ b/src/main/java/robinlb99/tienda/igu/Nueva_venta/ConfirmarCompra.java
@@ -65,12 +65,15 @@ public class ConfirmarCompra extends javax.swing.JFrame {
             public void actionPerformed(ActionEvent e) {
                 try {
                     // Tomo un cliente existente o creo uno nuevo.
-                    if (cliente.getId() == 0) {
-                        clt = cliente;
-                        control.crearCliente(clt);
-                    }
                     
-                    if (idTomado != 0) {
+                    if (idTomado == 0) {
+                        
+                        if (cliente.getId() == 0) {
+                            clt = cliente;
+                            control.crearCliente(clt);
+                        }
+                        
+                    } else if (idTomado != 0) {
                         clt = control.buscarCliente(idTomado);
                     }
 //                    System.out.println("\n" + clt.toString());
@@ -94,7 +97,7 @@ public class ConfirmarCompra extends javax.swing.JFrame {
                     pedido.setProductos(productos);
                     pedido.setValorCompra(valorPagar);
                     
-                    System.out.println(pedido.toString());
+//                    System.out.println(pedido.toString());
                     
                     control.crearPedido(pedido);
                     
@@ -114,7 +117,7 @@ public class ConfirmarCompra extends javax.swing.JFrame {
 
                 } catch (Exception ex) {
                     
-                    System.out.println(ex.getMessage());
+//                    System.out.println(ex.getMessage());
                     
                     window.mensaje("Error en la venta!", "error", "Ups! Hubo un error al realizar la venta.");
                     dispose();
@@ -128,6 +131,7 @@ public class ConfirmarCompra extends javax.swing.JFrame {
         btnCancelar.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                
                 dispose();
                 window.nuevaVenta(cFinal, idTomado, unidadesARestar);
             }
@@ -321,7 +325,7 @@ public class ConfirmarCompra extends javax.swing.JFrame {
             btnConfirmarCompra.setEnabled(true);
             
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+//            System.out.println(e.getMessage());
             window.mensaje("Error", "error", "El valor a ingresar debe ser numerico");
         }
         

--- a/src/main/java/robinlb99/tienda/igu/Nueva_venta/NuevaVenta.java
+++ b/src/main/java/robinlb99/tienda/igu/Nueva_venta/NuevaVenta.java
@@ -59,7 +59,7 @@ public class NuevaVenta extends javax.swing.JFrame {
             
             if (!cFinal) {
                 
-                System.out.println("El cliente es: " + cliente.toString());
+//                System.out.println("El cliente es: " + cliente.toString());
 
                 checkConsumidorFinal.setEnabled(false);
                 checkClientExist.setSelected(true);

--- a/src/main/java/robinlb99/tienda/igu/Nueva_venta/SeleccionProductos.java
+++ b/src/main/java/robinlb99/tienda/igu/Nueva_venta/SeleccionProductos.java
@@ -181,7 +181,7 @@ public class SeleccionProductos extends javax.swing.JFrame {
                             
                         } catch (Exception exc) {
                             
-                            System.out.println("Error: " + exc.getMessage());
+//                            System.out.println("Error: " + exc.getMessage());
                             exc.printStackTrace();
                             
                         }
@@ -244,7 +244,7 @@ public class SeleccionProductos extends javax.swing.JFrame {
                         
                     } catch (Exception ex) {
                         
-                        System.out.println(ex);
+//                        System.out.println(ex);
                         
                     }
                     
@@ -292,7 +292,7 @@ public class SeleccionProductos extends javax.swing.JFrame {
                         }
                                                 
                     } catch (Exception ex) {
-                        System.out.println(ex);
+//                        System.out.println(ex);
                     }
                 } else {
                     
@@ -332,7 +332,7 @@ public class SeleccionProductos extends javax.swing.JFrame {
                         
                         
                     } catch (Exception ex) {
-                        System.out.println(ex);
+//                        System.out.println(ex);
                     }
                 } else {
                     
@@ -358,10 +358,10 @@ public class SeleccionProductos extends javax.swing.JFrame {
             @Override
             public void actionPerformed(ActionEvent e) {
                 //Codigo
-                System.out.println("Lista de productos actual es: " + listaProductos.toString());
-                System.out.println("La lista de productos seleccionados es: " + productosSeleccionados.toString());
+//                System.out.println("Lista de productos actual es: " + listaProductos.toString());
+//                System.out.println("La lista de productos seleccionados es: " + productosSeleccionados.toString());
                 
-                System.out.println(productosSeleccionados.size());
+//                System.out.println(productosSeleccionados.size());
                 
                 for (ProductoUnidad prod : productosSeleccionados) {
                     


### PR DESCRIPTION
El error se producía cuando se marcaba la opción crédito, pasaba a la ventana de confirmación y luego cancelaba la operación. Luego al efectuar correctamente la operación, se creaba un registro de cliente nulo.